### PR TITLE
Actually make use of the db_host variable 

### DIFF
--- a/templates/wp-config.php.erb
+++ b/templates/wp-config.php.erb
@@ -24,7 +24,7 @@ define('DB_USER', '<%= @db_user %>');
 define('DB_PASSWORD', '<%= @db_password %>');
 
 /** MySQL hostname */
-define('DB_HOST', 'localhost');
+define('DB_HOST', '<%= @db_host %>');
 
 /** Database Charset to use in creating database tables. */
 define('DB_CHARSET', 'utf8');


### PR DESCRIPTION
Previously, although the prototype for the wordpress::db class accepts
a db_host argument, the actual db_host laid down by this template
did not make use of it.

This commit uses it from the class's scope for parallelism with
the other db_\* variables.
