### PR TITLE
Update Modulefile to use puppetlabs/concat.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,6 +8,6 @@ description 'Installs wordpress and required mysql db/user.'
 project_page 'https://github.com/hunner/puppet-wordpress'
 
 ## Add dependencies, if any:
-dependency 'ripienaar/concat', '>= 0.2.0'
+dependency 'puppetlabs/concat', '>= 1.0.0'
 dependency 'puppetlabs/mysql', '>= 0.5.0'
 dependency 'puppetlabs/stdlib', '>= 2.3.1'


### PR DESCRIPTION
I've checked that the specs still pass when using puppetlabs/concat vs ripienaar/concat. 

This will cause less confusion with people using puppetlabs/apache and trying to install this wordpress module since they won't have to remove the concat version they have before installing the other module.
