### PR TITLE
Revert "Merge pull request #18 from hunner/release_0.5.0"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,17 +1,3 @@
-2013-12-17 Release 0.5.0
-Features:
-- Add `wordpress::wp_proxy_host` and `wordpress::wp_proxy_port` for proxying
-plugin installation.
-- Add `wordpress::wp_mulitsite` and `wordpress::wp_multisite` to enable multisite support
-- Update to work with latest 2.x puppetlabs-mysql
-- Update to work with latest 1.x puppetlabs-concat
-- Add rspec-system integration testing, travis testing, and autopublish
-
-Bugfixes:
-- Fix ownership during installation to reduce log output and increase
-idempotency.
-
-
 2013-09-19 Release 0.4.2
 Bugfixes:
 - Correct Modulefile module name

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'hunner-wordpress'
-version '0.5.0'
+version '0.4.2'
 source 'https://github.com/hunner/puppet-wordpress'
 author 'Hunter Haugen'
 license 'Apache2'


### PR DESCRIPTION
I didn't mention the upgrade of wordpress, or check what this would do to existing wordpress installations. Backing out unreleased.

This reverts commit 6019ee133ad10159722d01e54ce1a1cd08576d8e, reversing
changes made to a6b7afb97f251ce10de4351234018d740e79d47b.
