### PR TITLE
Use ${wp_lang} as part of the name of the downloaded tar.gz

### DIFF
--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -51,11 +51,10 @@ class wordpress::app (
   
   ## tar.gz. file name lang-aware
   if $wp_lang {
-    $install_file_name = wordpress-${version}-${wp_lang}.tar.gz
+    $install_file_name = "wordpress-${version}-${wp_lang}.tar.gz"
   } else {
-    $install_file_name = wordpress-${version}.tar.gz
+    $install_file_name = "wordpress-${version}.tar.gz"
   }
-  
 
   ## Download and extract
   exec { 'Download wordpress':


### PR DESCRIPTION
The only way i've found to download wordpress in another language is add the desired language to the version parameter like this:

```
  class { 'wordpress':
    version => '3.8.1-es_ES',
    install_url => 'http://es.wordpress.org/',
```

It works, althought it doesn't look very kind as you are mixing version and language information.

It seems that wordpress' releases use the wp_lang parameter as part of the name of the tar.gz file (see examples below), so it looks safe to use this parameter to build the name of the file to download.

Some examples tested that follow this rule (more values from http://wpcentral.io/internationalization/)

http://eu.wordpress.org/wordpress-3.8.1-eu.tar.gz
http://es.wordpress.org/wordpress-3.8.1-es_ES.tar.gz
http://br.wordpress.org/wordpress-3.8.1-pt_BR.tar.gz
http://pt.wordpress.org/wordpress-3.8.1-pt_PT.tar.gz
http://de.wordpress.org/wordpress-3.8.1-de_DE.tar.gz
http://ja.wordpress.org/wordpress-3.8.1-ja.tar.gz
http://nn.wordpress.org/wordpress-3.8.1-nn_NO.tar.gz
