### PR TITLE
Add WP_DEBUG options to the wordpress app parameters

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -77,6 +77,15 @@ Requires:
 * `wp_site_domain`<br />
   Specifies the `DOMAIN_CURRENT_SITE` value that will be used when configuring multisite. Typically this is the address of the main wordpress instance.  Default: ''
 
+* `wp_debug`<br />
+  Specifies the `WP_DEBUG` value that will control debugging. This must be true if you use the next two debug extensions. Default: 'false'
+
+* `wp_debug_log`<br />
+  Specifies the `WP_DEBUG_LOG` value that extends debugging to cause all errors to also be saved to a debug.log logfile insdie the /wp-content/ directory. Default: 'false'
+
+* `wp_debug_display`<br />
+  Specifies the `WP_DEBUG_DISPLAY` value that extends debugging to cause debug messages to be shown inline, in HTML pages. Default: 'false'
+
 ## Example Usage
 
 Default deployment (insecure; default passwords and installed as root):

--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -16,13 +16,24 @@ class wordpress::app (
   $wp_proxy_port,
   $wp_multisite,
   $wp_site_domain,
+  $wp_debug,
+  $wp_debug_log,
+  $wp_debug_display
 ) {
   validate_string($install_dir,$install_url,$version,$db_name,$db_host,$db_user,$db_password,$wp_owner,$wp_group, $wp_lang, $wp_plugin_dir,$wp_additional_config,$wp_table_prefix,$wp_proxy_host,$wp_proxy_port,$wp_site_domain)
-  validate_bool($wp_multisite)
+  validate_bool($wp_multisite, $wp_debug, $wp_debug_log, $wp_debug_display)
   validate_absolute_path($install_dir)
 
   if $wp_multisite and ! $wp_site_domain {
     fail('wordpress class requires `wp_site_domain` parameter when `wp_multisite` is true')
+  }
+
+  if $wp_debug_log and ! $wp_debug {
+    fail('wordpress class requires `wp_debug` parameter to be true, when `wp_debug_log` is true')
+  }
+
+  if $wp_debug_display and ! $wp_debug {
+    fail('wordpress class requires `wp_debug` parameter to be true, when `wp_debug_display` is true')
   }
 
   ## Resource defaults
@@ -85,7 +96,7 @@ class wordpress::app (
     order   => '10',
     require => File["${install_dir}/wp-keysalts.php"],
   }
-  # Template uses: $db_name, $db_user, $db_password, $db_host, $wp_proxy, $wp_proxy_host, $wp_proxy_port, $wp_multisite, $wp_site_domain
+  # Template uses: $db_name, $db_user, $db_password, $db_host, $wp_proxy, $wp_proxy_host, $wp_proxy_port, $wp_multisite, $wp_site_domain, $wp_debug, $wp_debug_log, $wp_debug_display
   concat::fragment { 'wp-config.php body':
     target  => "${install_dir}/wp-config.php",
     content => template('wordpress/wp-config.php.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,15 @@
 # [*wp_site_domain*]
 #   Specifies the `DOMAIN_CURRENT_SITE` value that will be used when configuring multisite. Typically this is the address of the main wordpress instance.  Default: ''
 #
+# [*wp_debug*]
+#   Specifies the `WP_DEBUG` value that will control debugging. This must be true if you use the next two debug extensions. Default: 'false'
+#
+# [*wp_debug_log*]
+#   Specifies the `WP_DEBUG_LOG` value that extends debugging to cause all errors to also be saved to a debug.log logfile insdie the /wp-content/ directory. Default: 'false'
+#
+# [*wp_debug_display*]
+#   Specifies the `WP_DEBUG_DISPLAY` value that extends debugging to cause debug messages to be shown inline, in HTML pages. Default: 'false'
+#
 # === Requires
 #
 # === Examples
@@ -90,6 +99,9 @@ class wordpress (
   $wp_proxy_port        = '',
   $wp_multisite         = false,
   $wp_site_domain       = '',
+  $wp_debug             = false,
+  $wp_debug_log         = false,
+  $wp_debug_display     = false
 ) {
   anchor { 'wordpress::begin': }
   -> class { 'wordpress::app':
@@ -110,6 +122,9 @@ class wordpress (
     wp_proxy_port        => $wp_proxy_port,
     wp_multisite         => $wp_multisite,
     wp_site_domain       => $wp_site_domain,
+    wp_debug             => $wp_debug,
+    wp_debug_log         => $wp_debug_log,
+    wp_debug_display     => $wp_debug_display
   }
   -> class { 'wordpress::db':
     create_db      => $create_db,

--- a/templates/wp-config.php.erb
+++ b/templates/wp-config.php.erb
@@ -57,8 +57,21 @@ define('WPLANG', '<%= @wp_lang %>');
  * Change this to true to enable the display of notices during development.
  * It is strongly recommended that plugin and theme developers use WP_DEBUG
  * in their development environments.
+ * 
+ * WP_DEBUG_LOG is a companion to WP_DEBUG that causes all errors to also be 
+ * saved to a debug.log log file inside the /wp-content/ directory. This is 
+ * useful if you want to review all notices later or need to view notices 
+ * generated off-screen (e.g. during an AJAX request or wp-cron run).
+ * 
+ * WP_DEBUG_DISPLAY is another companion to WP_DEBUG that controls whether 
+ * debug messages are shown inside the HTML of pages or not. The default 
+ * is 'true' which shows errors and warnings as they are generated. Setting 
+ * this to false will hide all errors. This should be used in conjunction with 
+ * WP_DEBUG_LOG so that errors can be reviewed later.
  */
-define('WP_DEBUG', false);
+define('WP_DEBUG', <%= @wp_debug %>);
+define('WP_DEBUG_LOG', <%= @wp_debug_log %>);
+define('WP_DEBUG_DISPLAY', <%= @wp_debug_display %>);
 
 <% if @wp_plugin_dir != 'DEFAULT' %>
 define('WP_PLUGIN_DIR', '<%= @wp_plugin_dir %>');


### PR DESCRIPTION
The original implementation was using a define constant, which meant
that the additional configuration file could not override the pre-set
values from the initial template.

This commit adds:
- WP_DEBUG
- WP_DEBUG_LOG
- WP_DEBUG_DISPLAY

All values default to false, which matches the initial implementation
for WP_DEBUG and continues that intent for the new values.
