### PR TITLE
remove user from Exec defaults block

### DIFF
--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -35,7 +35,6 @@ class wordpress::app (
     path      => ['/bin','/sbin','/usr/bin','/usr/sbin'],
     cwd       => $install_dir,
     logoutput => 'on_failure',
-    user      => $wp_owner,
     group     => $wp_group,
   }
 


### PR DESCRIPTION
concat inherits the user value later on, which causes concat to attempt running as the wordpress user.  This fails due to dir permissions on /var/lib/puppet.

I suspect user was placed in the Exec block for a reason, but it's removal has not impacted anything yet on my  side.
