### PR TITLE
add option to conditionally not manage wp-config.php at all

### DIFF
--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -16,9 +16,10 @@ class wordpress::app (
   $wp_proxy_port,
   $wp_multisite,
   $wp_site_domain,
+  $manage_config = true
 ) {
   validate_string($install_dir,$install_url,$version,$db_name,$db_host,$db_user,$db_password,$wp_owner,$wp_group, $wp_lang, $wp_plugin_dir,$wp_additional_config,$wp_table_prefix,$wp_proxy_host,$wp_proxy_port,$wp_site_domain)
-  validate_bool($wp_multisite)
+  validate_bool($wp_multisite,$manage_config)
   validate_absolute_path($install_dir)
 
   if $wp_multisite and ! $wp_site_domain {
@@ -67,28 +68,30 @@ class wordpress::app (
   ## Configure wordpress
   #
   # Template uses no variables
-  file { "${install_dir}/wp-keysalts.php":
-    ensure  => present,
-    content => template('wordpress/wp-keysalts.php.erb'),
-    replace => false,
-    require => Exec['Extract wordpress'],
-  }
-  concat { "${install_dir}/wp-config.php":
-    owner   => $wp_owner,
-    group   => $wp_group,
-    mode    => '0755',
-    require => Exec['Extract wordpress'],
-  }
-  concat::fragment { 'wp-config.php keysalts':
-    target  => "${install_dir}/wp-config.php",
-    source  => "${install_dir}/wp-keysalts.php",
-    order   => '10',
-    require => File["${install_dir}/wp-keysalts.php"],
-  }
-  # Template uses: $db_name, $db_user, $db_password, $db_host, $wp_proxy, $wp_proxy_host, $wp_proxy_port, $wp_multisite, $wp_site_domain
-  concat::fragment { 'wp-config.php body':
-    target  => "${install_dir}/wp-config.php",
-    content => template('wordpress/wp-config.php.erb'),
-    order   => '20',
+  if $manage_config {
+    file { "${install_dir}/wp-keysalts.php":
+      ensure  => present,
+      content => template('wordpress/wp-keysalts.php.erb'),
+      replace => false,
+      require => Exec['Extract wordpress'],
+    }
+    concat { "${install_dir}/wp-config.php":
+      owner   => $wp_owner,
+      group   => $wp_group,
+      mode    => '0755',
+      require => Exec['Extract wordpress'],
+    }
+    concat::fragment { 'wp-config.php keysalts':
+      target  => "${install_dir}/wp-config.php",
+      source  => "${install_dir}/wp-keysalts.php",
+      order   => '10',
+      require => File["${install_dir}/wp-keysalts.php"],
+    }
+    # Template uses: $db_name, $db_user, $db_password, $db_host, $wp_proxy, $wp_proxy_host, $wp_proxy_port, $wp_multisite, $wp_site_domain
+    concat::fragment { 'wp-config.php body':
+      target  => "${install_dir}/wp-config.php",
+      content => template('wordpress/wp-config.php.erb'),
+      order   => '20',
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,7 +44,6 @@
 # [*wp_lang*]
 #   WordPress Localized Language. Default: ''
 #
-#
 # [*wp_plugin_dir*]
 #   WordPress Plugin Directory. Full path, no trailing slash. Default: WordPress Default
 #
@@ -65,6 +64,9 @@
 #
 # [*wp_site_domain*]
 #   Specifies the `DOMAIN_CURRENT_SITE` value that will be used when configuring multisite. Typically this is the address of the main wordpress instance.  Default: ''
+#
+# [*manage_config*]
+#   Boolean. If false, do not manage wp-config.php at all.
 #
 # === Requires
 #
@@ -90,6 +92,7 @@ class wordpress (
   $wp_proxy_port        = '',
   $wp_multisite         = false,
   $wp_site_domain       = '',
+  $manage_config        = true,
 ) {
   anchor { 'wordpress::begin': }
   -> class { 'wordpress::app':
@@ -110,6 +113,7 @@ class wordpress (
     wp_proxy_port        => $wp_proxy_port,
     wp_multisite         => $wp_multisite,
     wp_site_domain       => $wp_site_domain,
+    manage_config        => $manage_config,
   }
   -> class { 'wordpress::db':
     create_db      => $create_db,


### PR DESCRIPTION
We're spinning up WP in AWS, using pre-baked images and autoscaling. As a result, there's a lot of custom stuff in our WP config, _and_ the key/salt values should be the same across all instances. This adds an option to simply not manage wp-config.php at all, and allow a separate (custom, local) module to drop it in place from a template or static file.
