### PR TITLE
${wp_lang} as part of the name of the downloaded tar.gz

### DIFF
--- a/manifests/instance/app.pp
+++ b/manifests/instance/app.pp
@@ -62,17 +62,24 @@ define wordpress::instance::app (
   } else {
     notice("Warning: cannot manage the permissions of ${install_dir}, as another resource (perhaps apache::vhost?) is managing it.")
   }
+  
+  ## tar.gz. file name lang-aware
+  if $wp_lang {
+    $install_file_name = "wordpress-${version}-${wp_lang}.tar.gz"
+  } else {
+    $install_file_name = "wordpress-${version}.tar.gz"
+  }
 
   ## Download and extract
   exec { "Download wordpress ${install_url}/wordpress-${version}.tar.gz to ${install_dir}":
-    command => "wget ${install_url}/wordpress-${version}.tar.gz",
-    creates => "${install_dir}/wordpress-${version}.tar.gz",
+    command => "wget ${install_url}/${install_file_name}",
+    creates => "${install_dir}/${install_file_name}",
     require => File[$install_dir],
     user    => $wp_owner,
     group   => $wp_group,
   }
   -> exec { "Extract wordpress ${install_dir}":
-    command => "tar zxvf ./wordpress-${version}.tar.gz --strip-components=1",
+    command => "tar zxvf ./${install_file_name} --strip-components=1",
     creates => "${install_dir}/index.php",
     user    => $wp_owner,
     group   => $wp_group,


### PR DESCRIPTION
Re-adds changes introduced in  #40 that were overwritten by #36.
