### PR TITLE
Added wp_config_mode to allow changing wp-config.php permissions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,9 @@
 # [*wp_additional_config*]
 #   Specifies a template to include near the end of the wp-config.php file to add additional options. Default: ''
 #
+# [*wp_config_mode*]
+#   Specifies the file permissions of wp-config.php. Default: 0755
+#
 # [*wp_table_prefix*]
 #   Specifies the database table prefix. Default: wp_
 #
@@ -95,6 +98,7 @@ class wordpress (
   $wp_group             = '0',
   $wp_lang              = '',
   $wp_config_content    = undef,
+  $wp_config_mode       = '0755',
   $wp_plugin_dir        = 'DEFAULT',
   $wp_additional_config = 'DEFAULT',
   $wp_table_prefix      = 'wp_',
@@ -120,6 +124,7 @@ class wordpress (
     wp_group             => $wp_group,
     wp_lang              => $wp_lang,
     wp_config_content    => $wp_config_content,
+    wp_config_mode       => $wp_config_mode,
     wp_plugin_dir        => $wp_plugin_dir,
     wp_additional_config => $wp_additional_config,
     wp_table_prefix      => $wp_table_prefix,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -51,6 +51,9 @@
 # [*wp_additional_config*]
 #   Specifies a template to include near the end of the wp-config.php file to add additional options. Default: ''
 #
+# [*wp_config_mode*]
+#   Specifies the file permissions of wp-config.php. Default: 0755
+#
 # [*wp_table_prefix*]
 #   Specifies the database table prefix. Default: wp_
 #
@@ -84,6 +87,7 @@ define wordpress::instance (
   $wp_group             = '0',
   $wp_lang              = '',
   $wp_config_content    = undef,
+  $wp_config_mode       = '0755',
   $wp_plugin_dir        = 'DEFAULT',
   $wp_additional_config = 'DEFAULT',
   $wp_table_prefix      = 'wp_',
@@ -107,6 +111,7 @@ define wordpress::instance (
     wp_group             => $wp_group,
     wp_lang              => $wp_lang,
     wp_config_content    => $wp_config_content,
+    wp_config_mode       => $wp_config_mode,
     wp_plugin_dir        => $wp_plugin_dir,
     wp_additional_config => $wp_additional_config,
     wp_table_prefix      => $wp_table_prefix,

--- a/manifests/instance/app.pp
+++ b/manifests/instance/app.pp
@@ -10,6 +10,7 @@ define wordpress::instance::app (
   $wp_group,
   $wp_lang,
   $wp_config_content,
+  $wp_config_mode,
   $wp_plugin_dir,
   $wp_additional_config,
   $wp_table_prefix,
@@ -89,7 +90,7 @@ define wordpress::instance::app (
   concat { "${install_dir}/wp-config.php":
     owner   => $wp_owner,
     group   => $wp_group,
-    mode    => '0755',
+    mode    => $wp_config_mode,
     require => Exec["Extract wordpress ${install_dir}"],
   }
   if $wp_config_content {


### PR DESCRIPTION
In some environments, creating wp-config.php with 0755 permissions can be unsecure because it contains sensitive data, like the database password, in plain text.

This change, allows the user to specify another value (like 0600, more convenient in shared servers) but leaves default value unchanged (0755) so working projects should not be affected.
