### PR TITLE
Use license.txt instead of index.php to trigger new version install

### DIFF
--- a/manifests/instance/app.pp
+++ b/manifests/instance/app.pp
@@ -80,7 +80,7 @@ define wordpress::instance::app (
   }
   -> exec { "Extract wordpress ${install_dir}":
     command => "tar zxvf ./${install_file_name} --strip-components=1",
-    creates => "${install_dir}/index.php",
+    creates => "${install_dir}/license.txt",
     user    => $wp_owner,
     group   => $wp_group,
   }


### PR DESCRIPTION
Currently in order to deploy a new version of wordpress using the module you not only have to change the version number, you also have to remove index.php, which unpacks a new version. removing index.php breaks cite, so it's safer to remove license.txt file instead and use presence of this file as a 'trigger' 
