### PR TITLE
Enable support for wp_cache

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -92,6 +92,9 @@ This will set up one or more installations of Wordpress 3.8 on Debian and Redhat
 * `wp_debug_display`<br />
   Specifies the `WP_DEBUG_DISPLAY` value that extends debugging to cause debug messages to be shown inline, in HTML pages. Default: 'false'
 
+* `wp_cache`<br />
+  Specifies whether to enable caching in Wordpress. Required for some caching plugins. Default: 'false'
+
 ### Define wordpress::instance
 
 * The parameters for `wordpress::instance` is exactly the same as the class `wordpress` except as noted below.

--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -20,6 +20,7 @@ class wordpress::app (
   $wp_debug,
   $wp_debug_log,
   $wp_debug_display,
+  $wp_cache,
 ) {
   wordpress::instance::app { $install_dir:
     install_dir          => $install_dir,
@@ -42,5 +43,6 @@ class wordpress::app (
     wp_debug             => $wp_debug,
     wp_debug_log         => $wp_debug_log,
     wp_debug_display     => $wp_debug_display,
+    wp_cache             => $wp_cache,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,6 +105,7 @@ class wordpress (
   $wp_debug             = false,
   $wp_debug_log         = false,
   $wp_debug_display     = false,
+  $wp_cache             = false,
 ) {
   wordpress::instance { $install_dir:
     install_dir          => $install_dir,
@@ -130,5 +131,6 @@ class wordpress (
     wp_debug             => $wp_debug,
     wp_debug_log         => $wp_debug_log,
     wp_debug_display     => $wp_debug_display,
+    wp_cache             => $wp_cache,
   }
 }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -94,6 +94,7 @@ define wordpress::instance (
   $wp_debug             = false,
   $wp_debug_log         = false,
   $wp_debug_display     = false,
+  $wp_cache             = false,
 ) {
   wordpress::instance::app { $install_dir:
     install_dir          => $install_dir,
@@ -117,6 +118,7 @@ define wordpress::instance (
     wp_debug             => $wp_debug,
     wp_debug_log         => $wp_debug_log,
     wp_debug_display     => $wp_debug_display,
+    wp_cache             => $wp_cache,
   }
 
   wordpress::instance::db { "${db_host}/${db_name}":

--- a/manifests/instance/app.pp
+++ b/manifests/instance/app.pp
@@ -20,6 +20,7 @@ define wordpress::instance::app (
   $wp_debug,
   $wp_debug_log,
   $wp_debug_display,
+  $wp_cache,
 ) {
   validate_string($install_dir,$install_url,$version,$db_name,$db_host,$db_user,$db_password,$wp_owner,$wp_group, $wp_lang, $wp_plugin_dir,$wp_additional_config,$wp_table_prefix,$wp_proxy_host,$wp_proxy_port,$wp_site_domain)
   validate_bool($wp_multisite, $wp_debug, $wp_debug_log, $wp_debug_display)
@@ -135,6 +136,7 @@ define wordpress::instance::app (
     # - $wp_debug
     # - $wp_debug_log
     # - $wp_debug_display
+    # - $wp_cache
     concat::fragment { "${install_dir}/wp-config.php body":
       target  => "${install_dir}/wp-config.php",
       content => template('wordpress/wp-config.php.erb'),

--- a/templates/wp-config.php.erb
+++ b/templates/wp-config.php.erb
@@ -73,6 +73,9 @@ define('WP_DEBUG', <%= @wp_debug %>);
 define('WP_DEBUG_LOG', <%= @wp_debug_log %>);
 define('WP_DEBUG_DISPLAY', <%= @wp_debug_display %>);
 
+/** WordPress caching */
+define('WP_CACHE', <%= @wp_cache %>);
+
 <% if @wp_plugin_dir != 'DEFAULT' %>
 define('WP_PLUGIN_DIR', '<%= @wp_plugin_dir %>');
 <% end %>


### PR DESCRIPTION
This change enables support for setting the `wp_cache` option in `wp-config.php` which is required for some third-party caching plugins.
