### PR TITLE
use tar with --dereference to follow symlinks required if wp-content …

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,7 +83,7 @@
 #
 class wordpress (
   $install_dir          = '/opt/wordpress',
-  $install_url          = 'http://wordpress.org',
+  $install_url          = 'https://wordpress.org',
   $version              = '3.8',
   $create_db            = true,
   $create_db_user       = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,7 +93,7 @@ class wordpress (
   $db_password          = 'password',
   $wp_owner             = 'root',
   $wp_group             = '0',
-  $wp_lang              = '',
+  $wp_lang              = undef,
   $wp_config_content    = undef,
   $wp_plugin_dir        = 'DEFAULT',
   $wp_additional_config = 'DEFAULT',

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -74,7 +74,7 @@ define wordpress::instance (
   $db_name,
   $db_user,
   $install_dir          = $title,
-  $install_url          = 'http://wordpress.org',
+  $install_url          = 'https://wordpress.org',
   $version              = '3.8',
   $create_db            = true,
   $create_db_user       = true,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -82,7 +82,7 @@ define wordpress::instance (
   $db_password          = 'password',
   $wp_owner             = 'root',
   $wp_group             = '0',
-  $wp_lang              = '',
+  $wp_lang              = undef,
   $wp_config_content    = undef,
   $wp_plugin_dir        = 'DEFAULT',
   $wp_additional_config = 'DEFAULT',

--- a/manifests/instance/app.pp
+++ b/manifests/instance/app.pp
@@ -79,7 +79,7 @@ define wordpress::instance::app (
     group   => $wp_group,
   }
   -> exec { "Extract wordpress ${install_dir}":
-    command => "tar zxvf ./${install_file_name} --strip-components=1",
+    command => "tar zxvf ./${install_file_name} --dereference --strip-components=1",
     creates => "${install_dir}/index.php",
     user    => $wp_owner,
     group   => $wp_group,


### PR DESCRIPTION
use tar with --dereference to follow symlinks required if wp-content directory is a symlink

this is handy if you have a symlink for the wp-content to another location
